### PR TITLE
feat: disable postcss-retina-bg-img warning

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -14,7 +14,10 @@ module.exports = {
 		require('postcss-dir-pseudo-class'),
 		require('postcss-preset-env'),
 		require('postcss-nested'),
-		require('postcss-retina-bg-img')({ retinaSuffix: '@2x' }),
+		require('postcss-retina-bg-img')({
+			retinaSuffix: '@2x',
+			logMissingImages: false,
+		}),
 		require('cssnano'),
 		require('postcss-reporter')({ clearReportedMessages: true }),
 	],


### PR DESCRIPTION
postcss-retina-bg-img display warnings when an image doesn't have a retina version. In most cases this is intentional and the warnings clutter the console. The new version has an option to disable that.